### PR TITLE
[RC1] addServers works almost same as in Gearman PECL library.

### DIFF
--- a/lib/Net/Gearman/Client.php
+++ b/lib/Net/Gearman/Client.php
@@ -74,8 +74,12 @@ class Client implements ServerSetting
         return array_keys($this->servers);
     }
 
-    public function addServers(array $servers)
+    public function addServers($servers)
     {
+        if (!is_array($servers)) {
+            $servers = explode(',', $servers);
+        }
+
         foreach ($servers as $server) {
             $explodedServer = explode(':', $server);
             $port = isset($explodedServer[1]) ? $explodedServer[1] : null;
@@ -86,22 +90,20 @@ class Client implements ServerSetting
         return $this;
     }
 
-    public function addServer($host = null , $port = null)
+    public function addServer($host = 'localhost' , $port = null)
     {
-        if (null === $host) {
-            $host = 'localhost';
-        } else {
-            $host = trim($host);
-        }
-
+        $host = trim($host);
         if (empty($host)) {
             throw new \InvalidArgumentException("Invalid host '$host' given");
         }
 
         if (null === $port) {
             $port = $this->getDefaultPort();
-        } elseif (empty($port)) {
-            throw new \InvalidArgumentException("Invalid port '$port' given");
+        } else {
+            $port = (int) $port;
+            if (!$port > 0) {
+                throw new \InvalidArgumentException("Invalid port '$port' given");
+            }
         }
 
         $server = $host . ':' . $port;

--- a/lib/Net/Gearman/ServerSetting.php
+++ b/lib/Net/Gearman/ServerSetting.php
@@ -14,12 +14,12 @@ interface ServerSetting
      * @throws \InvalidArgumentException
      * @return self
      */
-    public function addServer($host = null , $port = null);
+    public function addServer($host = 'localhost' , $port = null);
 
     /**
-     * @param string[] $servers
+     * @param string|array $servers Servers separated with comma, or array of servers
      * @throws \InvalidArgumentException
      * @return self
      */
-    public function addServers(array $servers);
+    public function addServers($servers);
 }

--- a/lib/Net/Gearman/Worker.php
+++ b/lib/Net/Gearman/Worker.php
@@ -106,8 +106,12 @@ class Worker implements ServerSetting
         return array_keys($this->servers);
     }
 
-    public function addServers(array $servers)
+    public function addServers($servers)
     {
+        if (!is_array($servers)) {
+            $servers = explode(',', $servers);
+        }
+
         foreach ($servers as $server) {
             $explodedServer = explode(':', $server);
             $port = isset($explodedServer[1]) ? $explodedServer[1] : null;
@@ -118,22 +122,20 @@ class Worker implements ServerSetting
         return $this;
     }
 
-    public function addServer($host = null , $port = null)
+    public function addServer($host = 'localhost' , $port = null)
     {
-        if (null === $host) {
-            $host = 'localhost';
-        } else {
-            $host = trim($host);
-        }
-
+        $host = trim($host);
         if (empty($host)) {
             throw new \InvalidArgumentException("Invalid host '$host' given");
         }
 
         if (null === $port) {
             $port = $this->getDefaultPort();
-        } elseif (empty($port)) {
-            throw new \InvalidArgumentException("Invalid port '$port' given");
+        } else {
+            $port = (int) $port;
+            if (!$port > 0) {
+                throw new \InvalidArgumentException("Invalid port '$port' given");
+            }
         }
 
         $server = $host . ':' . $port;

--- a/tests/Net/Gearman/ServerSettingTest.php
+++ b/tests/Net/Gearman/ServerSettingTest.php
@@ -124,6 +124,23 @@ class ServerSettingTest extends \PHPUnit_Framework_TestCase
     /**
      * @param ServerSetting $serverSetting
      * @dataProvider serverSettingImplementationDataProvider
+     */
+    public function testAddServersAsString(ServerSetting $serverSetting)
+    {
+        $servers = 'localhost,localhost:1234,  example.com:4730';
+        $serverSetting->addServers($servers);
+
+        $servers = array(
+            'localhost:4730',
+            'localhost:1234',
+            'example.com:4730'
+        );
+        $this->assertEquals($servers, $serverSetting->getServers());
+    }
+
+    /**
+     * @param ServerSetting $serverSetting
+     * @dataProvider serverSettingImplementationDataProvider
      * @expectedException \InvalidArgumentException
      */
     public function testAddServersThrowsExceptionIfServerAlreadyExists(ServerSetting $serverSetting)


### PR DESCRIPTION
Usecase from PHP PECL gearman extension

``` php
<?php

$worker= new GearmanWorker(); 
$worker->addServers("10.0.0.1,10.0.0.2:7003");

?>
```

In this library you can also pass an array. It is up to developer if he passes hosts with ports as string or as array.
