### PR TITLE
worker() throws notice when there are no abilities listed

### DIFF
--- a/lib/Net/Gearman/Manager.php
+++ b/lib/Net/Gearman/Manager.php
@@ -142,11 +142,12 @@ class Manager
             if (!Connection::stringLength($t)) {
                 continue;
             }
-
-            list($info, $abilities) = explode(" : ", $t);
-            list($fd, $ip, $id)     = explode(' ', $info);
-
-            $abilities = trim($abilities);
+	    
+	    
+            $info = explode(" : ", $t);
+            list($fd, $ip, $id)     = explode(' ', $info[0]);
+	
+            $abilities = isset($info[1]) ? trim($info[1]) : '';
 
             $workers[] = array(
                 'fd' => $fd,


### PR DESCRIPTION
Was testing the Manager functionality for worker().  I haven't started any workers on my gearman server yet, curious what it would report.  It reported the connection I was connecting the Manager to.  but had no abilities.  and reported a Notice Undefined offset due to the unchecked use of list.
