### PR TITLE
fixed Fatal error: Wrong parameters for Exception

### DIFF
--- a/lib/Net/Gearman/Client.php
+++ b/lib/Net/Gearman/Client.php
@@ -260,7 +260,7 @@ class Client implements ServerSetting
      * @param integer $epoch Time of job to run at (unix timestamp)
      * @return Set
      */
-    private function createSet($functionName, $workload, $unique = null, $type = Task::JOB_NORMAL, $epoch = 0)
+    public function createSet($functionName, $workload, $unique = null, $type = Task::JOB_NORMAL, $epoch = 0)
     {
         if (null === $unique) {
             $unique = $this->generateUniqueId();
@@ -274,6 +274,26 @@ class Client implements ServerSetting
         return $set;
     }
 
+    /**
+     * Create a single task
+     *
+     * @param string $functionName
+     * @param string $workload
+     * @param string $unique
+     * @param integer $type Type of job to run task as
+     * @param integer $epoch Time of job to run at (unix timestamp)
+     * @return Task
+     */
+    public function newTask($functionName, $workload, $unique = null, $type = Task::JOB_NORMAL, $epoch = 0)
+    {
+        if (null === $unique) {
+            $unique = $this->generateUniqueId();
+        }
+
+        $task = new Task($functionName, $workload, $unique, $type, $epoch);
+        return $task;
+    }
+    
     /**
      * @return string
      */

--- a/lib/Net/Gearman/Connection.php
+++ b/lib/Net/Gearman/Connection.php
@@ -298,7 +298,7 @@ class Connection
             }
 
             throw new Exception(
-                $return['err_text'], $return['err_code']
+                $return['err_text']
             );
         }
 

--- a/lib/Net/Gearman/Connection.php
+++ b/lib/Net/Gearman/Connection.php
@@ -298,7 +298,7 @@ class Connection
             }
 
             throw new Exception(
-                $return['err_text']
+                "{$return['err_text']} - {$return['err_code']}"
             );
         }
 


### PR DESCRIPTION
This fixes https://github.com/Publero/net_gearman/issues/7

Gearman returns a string as an error code "queue_full" so it doesn't make a whole lot of sense to pass this as the error code of the exception class, which expects a long.
