### PR TITLE
Base64 encode strings before handing them off to Gearman.

### DIFF
--- a/lib/Net/Gearman/Client.php
+++ b/lib/Net/Gearman/Client.php
@@ -266,6 +266,8 @@ class Client implements ServerSetting
             $unique = $this->generateUniqueId();
         }
 
+        // the workload string needs to have null-bytes escaped
+        $workload = base64_encode($workload);
         $task = new Task($functionName, $workload, $unique, $type, $epoch);
         $task->type = $type;
         $set = new Set();

--- a/lib/Net/Gearman/Worker.php
+++ b/lib/Net/Gearman/Worker.php
@@ -362,6 +362,7 @@ class Worker implements ServerSetting
             }
         }
 
+        $arg = base64_decode($arg);
         try {
             $this->callStartCallbacks($handle, $name, $arg);
 


### PR DESCRIPTION
Strings that contain null-bytes cannot be properly passed off to Gearman. For example:

``` php
<?php // client.php
require_once __DIR__.'/vendor/autoload.php';
$client = new \Net\Gearman\Client();
$client->addServer('localhost', 4730);
$data = 'test'."\0".'string';
echo 'Sent: '.$data.PHP_EOL;
$client->doBackground('nullString', $data);
```

``` php
<?php // worker.php
require_once __DIR__.'/vendor/autoload.php';
$worker = new \Net\Gearman\Worker();
$worker->addServer('localhost', 4730);
$worker->addFunction('nullString', function($data) {
    echo 'Received: '.$data.PHP_EOL;
    return true;
});
$worker->work();
```

``` shell
$> php client.php
Sent: teststring
```

``` shell
$> php worker.php
Received: test
```

This patch uses `base64_encode` and `base64_decode` to transparently ensure that the string sent from the client arrives at the workload identically.
