### PR TITLE
Workaround for HHVM.

### DIFF
--- a/lib/Net/Gearman/Connection.php
+++ b/lib/Net/Gearman/Connection.php
@@ -365,9 +365,13 @@ class Connection
      */
     static public function isConnected($conn)
     {
+        $validResources = [
+            'socket' => true,
+            'stream' => true
+        ];
         return (is_null($conn) !== true &&
                 is_resource($conn) === true &&
-                strtolower(get_resource_type($conn)) == 'socket');
+                !empty($validResources[strtolower(get_resource_type($conn))]));
     }
 
     /**

--- a/tests/Net/Gearman/ConnectionTest.php
+++ b/tests/Net/Gearman/ConnectionTest.php
@@ -26,8 +26,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertInternalType('resource', $connection);
-        $this->assertEquals('socket', strtolower(get_resource_type($connection)));
-
+        $this->assertTrue(in_array(strtolower(get_resource_type($connection)), ['socket', 'stream']));
         $this->assertTrue(Connection::isConnected($connection));
 
         Connection::close($connection);


### PR DESCRIPTION
HHVM's implementation of `socket_create` returns a resource of type `"stream"` instead of type `"socket"` causing `Net\Gearman\Connection::isConnected` to return false even when the connection is a perfectly useable resource.

See: https://github.com/facebook/hhvm/issues/4036
